### PR TITLE
Expand Kokkos description

### DIFF
--- a/_sw/kokkos.md
+++ b/_sw/kokkos.md
@@ -3,5 +3,14 @@ title: Kokkos
 area: PMR
 e4s_member: true
 member_org: s4pst
+owner: Linux Foundation - HPSF
+target_audience: library and application developers
 ---
-Kokkos implements a programming model in C++ for writing performance portable applications targeting all major HPC platforms
+
+The Kokkos Ecosystem provides a programming system designed for performance portability across all major HPC architectures.
+At its core stands the Kokkos programming model, that combines data management and parallel execution capabilities to enable
+writing performance portable software. On top of that the ecosystem provides higher level building blocks for scientific
+and engineering software such as math libraries, communication interfaces and tools for debugging and profiling.
+
+The Kokkos project is a Linux Foundation project and part of HPSF.
+


### PR DESCRIPTION
I think we need an "owner" field to list who controls/governs the project. I.e. Kokkos is a Linux Foundation project, OpenMP has its Review Board, OpenMPI has the OpenMPI foundation thing I believe, Julia has its own thing, LLVM has its own etc. Listing these makes it clearer that CASS is not claiming "ownership" over these projects and may in some cases be necessary due to crediting requirements. 