### PR TITLE
Spack: Enable Download label with link to releases

### DIFF
--- a/_sw/spack.md
+++ b/_sw/spack.md
@@ -32,8 +32,8 @@ additional_resource_links:
     url: https://spack.io/
   - label: Repository
     url: https://github.com/spack/spack
-  # - label: Downloads
-  #   url: 
+  - label: Downloads
+    url: https://github.com/spack/spack/releases
   - label: Documentation
     url: https://spack.readthedocs.io
 ---


### PR DESCRIPTION
Fixes #55 

Mimic the approach used by other codes (e.g., `adios`)  w.r.t. the `Download` link in terms of adding the link to Spack's `Releases`.