### PR TITLE
Add software mentions to featured highlights on main page

### DIFF
--- a/_includes/hl-archive-single.html
+++ b/_includes/hl-archive-single.html
@@ -55,6 +55,8 @@
 {% assign teaser = post.teaser | prepend: "/assets/impacts/" | relative_url %}
 {% endif %}
 
+{% capture sw_icon %}{% include icon-map-lookup label="Software" %}{% endcapture %}
+{% capture mentions_heading %}{{ sw_icon }} Software mentioned:{% endcapture %}
 
 <div class="{{ include.type | default: 'list' }}__item">
   <article class="archive__item" itemscope itemtype="https://schema.org/CreativeWork"{% if post.locale %} lang="{{ post.locale }}"{% endif %}>
@@ -75,5 +77,7 @@
     {% if post.date %}<p class="archive__item-excerpt" itemprop="date">Date: {{ post.date | date: date_format }}</p>{% endif %}
     {% if post.excerpt %}<p class="archive__item-excerpt clearfix" itemprop="description">
       {{ post.excerpt | markdownify | strip_html | truncatewords: 50 }}</p>{% endif %}
+    {% if post.software_mentioned %}<p class="archive__item-excerpt clearfix" itemprop="description">
+      {% include show-software-mentioned.html heading=mentions_heading mentions=post.software_mentioned %}</p>{% endif %}
   </article>
 </div>

--- a/_includes/hl-feature-row
+++ b/_includes/hl-feature-row
@@ -15,7 +15,10 @@
     no_border: modify style to eliminate bottom border rule
 {% endcomment %}
 {% assign highlights = include.highlights | default: site.data.featured-stories %}
-{% assign collection = include.collection | default: "impacts" %}
+{% assign hl_collection = include.collection | default: site.impacts %}
+
+{% capture sw_icon %}{% include icon-map-lookup label="Software" %}{% endcapture %}
+{% capture mentions_heading %}{{ sw_icon }} Software mentioned:{% endcapture %}
 
 {% assign image_path = "" | split: "," %}
 {% assign title = "" | split: "," %}
@@ -24,14 +27,21 @@
 
 {% for h in highlights %}
   {% assign query = "item.url contains '" | append: h | append: "'" %}
-  {% assign hl = site[collection] | where_exp: "item", query %}
+  {% assign hl = hl_collection | where_exp: "item", query %}
   {% assign img = hl[0].teaser %}
   {% capture teaser %}{% include hl-image-path image=img %}{% endcapture %}
   {% assign image_path = image_path | push: teaser %}
   {% assign title = title | push: hl[0].title %}
   {% assign url = hl[0].url | relative_url %}
   {% assign title_url = title_url | push: url %}
-  {% assign excerpt = excerpt | push: hl[0].excerpt %}
+  {% assign my_excerpt = hl[0].excerpt %}
+  {% if hl[0].software_mentioned %}
+    {% assign mentions = hl[0].software_mentioned %}
+    {% capture formatted_mentions %}{% include show-software-mentioned.html mentions=mentions heading=mentions_heading %}{% endcapture %}
+    {% assign my_excerpt = my_excerpt | append: formatted_mentions %}
+  {% endif %}
+  {% assign excerpt = excerpt | push: my_excerpt %}
 {% endfor %}
 
 {% include flexible_feature_row no_border=true image_path=image_path title=title title_url=title_url excerpt=excerpt %}
+  

--- a/_includes/show-software-mentioned.html
+++ b/_includes/show-software-mentioned.html
@@ -8,12 +8,14 @@ Parameters
   collection: collection to lookup products (OPTIONAL, default: site.software)
 {% endcomment %}
 {% capture sw_icon %}{% include icon-map-lookup label="Software" %}{% endcapture %}
+{% capture default_heading %}{{ sw_icon }}<strong>Software mentioned:</strong>{% endcapture %}
+{% assign heading = include.heading | default: default_heading -%}
 {% assign mentions = include.mentions | default: page.software_mentioned %}
 {% assign collection = include.collection | default: site.software -%}
 {% if mentions %}
-  <p id="software-mentioned"><strong>{{ sw_icon }} Software mentioned:</strong>
+  <span id="software-mentioned">{{ heading }}
     {% for product in mentions -%}
-      {% include sw-link-mention.html product=product collection=collection %}{% unless forloop.last %}, {% endunless -%}
+      {% include sw-link-mention.html product=product collection=collection mentions=mentions %}{% unless forloop.last %}, {% endunless -%}
     {% endfor -%}
-    </p>
+  </span>
 {% endif %}

--- a/_layouts/hl-page.html
+++ b/_layouts/hl-page.html
@@ -75,7 +75,7 @@ layout: default
           Display software mentions and CASS member information
         {% endcomment %}
         {% if page.software_mentioned %}
-          {% include show-software-mentioned.html %}
+          <p>{% include show-software-mentioned.html %}</p>
           {% capture m %}{% include cass-members-represented %}{% endcapture %}
           {% assign m = m | strip_newlines | split: "|" %}
           {% include show-cass-members.html cass_members=m highlight=true %}


### PR DESCRIPTION
Hal asked for the software mentioned in the highlights to appear on the featured highlights on the main page.

This change also adds it to the highlight collection entries on the Impacts page.