### PR TITLE
Fix some problems with the calendar page

### DIFF
--- a/_data/organization.yml
+++ b/_data/organization.yml
@@ -100,3 +100,11 @@ officers:
   - position: Secretary
     name: Todd Munson
     elected: 2024-10-07
+
+# Timelines for elections and reviews
+# Set in the by-laws
+#
+officers_term: 365 # days
+wg_reviews:
+  provisional: 182 # days
+  active: 365 # days

--- a/internal/calendar.md
+++ b/internal/calendar.md
@@ -10,28 +10,19 @@ header:
   overlay_filter: rgba(0, 146, 202, 0.75) # Same color as "air" skin footer
   overlay_image: /assets/images/tim-mossholder-GmvH5v9l3K4-unsplash.jpg
   caption: 'Photo by <a href="https://unsplash.com/@timmossholder">Tim Mossholder</a> on <a href="https://unsplash.com/photos/cogs-and-gears-GmvH5v9l3K4">Unsplash</a>'
-#
-#
-# Timelines defined in the by-laws
-#
-officers_term: 365 # days
-wg_reviews:
-  provisional: 180 # days
-  active: 365 # days
 ---
-
 *The resources linked from this page are intended for internal use by CASS members. Nothing in the internal tree should be linked from any public webpage.*
 
 ## Officer election deadlines
 
-Per the by-laws, officers serve a term of **{{ page.officers_term | default: '<em><font color="red">missing data</font></em>' }}** days.
-For the purposes of this page, the term is set by the variable `officers_term` in the source for this page. ({% include github_edit_link %})
+Per the by-laws, officers serve a term of **{{ site.data.organization.officers_term | default: '<em><font color="red">missing data</font></em>' }}** days.
+For the purposes of this page, the term is set by the variable `officers_term` in the file `_data/organization.yml`. ({% include github_edit_link path="_data/organization.yml" %})
 
 Due dates within 30 days are highlighted in blue. Overdue items are highlighted in red. (From last site build: {{ site.time | date: "%F" }})
 
 {% assign cal = "" | split: "|" %}
 {% for o in site.data.organization.officers -%}
-  {%- capture expiration %}{% include days-ahead date=o.elected days=page.officers_term %}{% endcapture -%}
+  {%- capture expiration %}{% include days-ahead date=o.elected days=site.data.organization.officers_term %}{% endcapture -%}
   {% assign line = expiration | append: "|" | append: o.position | append: "|" | append: o.name | append: "|" | append: o.elected %}
   {% assign cal = cal | push: line %}
 {% endfor %}
@@ -54,14 +45,20 @@ Due dates within 30 days are highlighted in blue. Overdue items are highlighted 
 
 ## Working group review deadlines
 
-Per the by-laws, provisional working groups should be reviewed after **{{ page.wg_reviews.provisional | default: '<em><font color="red">missing data</font></em>' }}** days and active working groups should be reviewed every **{{ page.wg_reviews.active | default: '<em><font color="red">missing data</font></em>' }}** days.
-For the purposes of this page, these terms are set by the variable `wg_reviews` in the source for this page. ({% include github_edit_link %})
+Per the by-laws, provisional working groups should be reviewed after **{{ site.data.organization.wg_reviews.provisional | default: '<em><font color="red">missing data</font></em>' }}** days and active working groups should be reviewed every **{{ site.data.organization.wg_reviews.active | default: '<em><font color="red">missing data</font></em>' }}** days.  Retired working groups do not require on-going review.
+For the purposes of this page, these terms are set by the variable `wg_reviews` in the file `_data/organization.yml`. ({% include github_edit_link path="_data/organization.yml" %})
 
 Due dates within 30 days are highlighted in blue. Overdue items are highlighted in red. (From last site build: {{ site.time | date: "%F" }})
 
 {% assign cal = "" | split: "|" %}
 {% for wg in site.working-groups %}
-  {%- capture expiration %}{% include days-ahead date=wg.charter.status_date days=page.wg_reviews.provisional %}{% endcapture -%}
+  {%- if wg.charter.status == "Provisional" %}
+    {%- capture expiration %}{% include days-ahead date=wg.charter.status_date days=site.data.organization.wg_reviews.provisional %}{% endcapture -%}
+  {% elsif wg.charter.status == "Active" %}
+    {%- capture expiration %}{% include days-ahead date=wg.charter.status_date days=site.data.organization.wg_reviews.active %}{% endcapture -%}
+  {% elsif wg.charter.status == "Retired" %}
+    {%- assign expiration = "9999-12-31" -%}
+  {% endif -%}
   {%- capture name %}[{{ wg.name }}]({{ wg.url }}){% endcapture -%}
   {%- assign chair = wg.chair | array_to_sentence_string -%}
   {%- assign email = "mailto:" -%}
@@ -87,6 +84,9 @@ Due dates within 30 days are highlighted in blue. Overdue items are highlighted 
     {% assign expiration = expiration | prepend: '<em><font color="red">' | append: '</font></em>' %}
   {% elsif remaining < 30 %}
     {% assign expiration = expiration | prepend: '<em><font color="blue">' | append: '</font></em>' %}
+  {% endif -%}
+  {%- if expiration == "9999-12-31" %}
+    {% assign expiration = "<em>not required</em>" -%}
   {% endif -%}
   {{ expiration }} | {{ fields[1] }} | {{ fields[2] }} | {{ fields[3] }} | {{ fields[4] }}
 {% endfor %}


### PR DESCRIPTION
Need the timeline variable to be usable from multiple pages (including about.md), so moved them back to `_data/organization.yml`.

Forgot to cover working group statuses besides Provisional.