### PR TITLE
Update software ecosystem WG charter and schedule

### DIFF
--- a/_working-groups/software-ecosystem.md
+++ b/_working-groups/software-ecosystem.md
@@ -19,7 +19,7 @@ description: Planning and executing activities that support and enhance holistic
 #
 charter:
   purpose: |
-    The CASS Software Ecosystem Working Group focuses on sustaining and improving collaboration across the CASS community and on promoting activities that support the scientific software ecosystem.  Our efforts include promoting a curated portfolio of independently developed, interoperable, and interchangeable libraries and tools that enable the development and use of application codes in the pursuit of scientific discovery.  We interpret the opportunities broadly to include community development, outreach, best practices in adopting and using the software portfolio, and more.
+    The CASS Software Ecosystem Working Group focuses on sustaining and improving collaboration across the CASS community and on promoting activities that support the scientific software ecosystem.  Our efforts include coordinating CASS birds-of-a-feather events, promoting a curated portfolio of independently developed, interoperable, and interchangeable libraries and tools that enable the development and use of application codes in the pursuit of scientific discovery, including in particular the curation of the E4S website.  We interpret the opportunities broadly to include community development, outreach, best practices in adopting and using the software portfolio, and more. Specific members include software coordinators from other product-owning software stewardship organizations.
   relationships: |
     The software ecosystem working group's efforts often align with those of the Software Integration, Impact Framework, and User-Developer Experience (UDX) working groups.
   lifetime: Standing
@@ -33,7 +33,7 @@ chair: # Can be more than one person
 #
 # A simple statement of the meeting schedule, if you have one
 #
-meeting_schedule: "4:00 pm-5:00 pm ET, every other Tuesday, including Sep 30, 2025"
+meeting_schedule: "1:00 pm-2:00 pm ET, every fourth Wednesday, including Jan 21, 2026"
 #
 # A way of easily providing additional resources/links
 #
@@ -41,4 +41,7 @@ additional_resource_links:
   - label: Slack channel
     note: "#wg-ecosystem"
     url: https://softwareecosy-91t5745.slack.com/archives/C07CBNGJ7UN
+  - label: Mail list
+    note: "Subscribe to this groups.io list to join"
+    url: https://groups.io/g/cass-sci-soft-ecosystem-wg
 ---


### PR DESCRIPTION
Expanded the charter to include coordination of birds-of-a-feather events and curation of the E4S website, and clarified member roles. Changed meeting schedule to every fourth Wednesday, 1:00 pm-2:00 pm ET. Added a mail list link to additional resources.