### PR TITLE
Replace rotten link in HPCToolkit

### DIFF
--- a/_data/icon-map.yml
+++ b/_data/icon-map.yml
@@ -22,6 +22,10 @@
   icon: <i class="fa-regular fa-fw fa-file-lines"></i>
 - label: User's guide
   icon: <i class="fa-regular fa-fw fa-file-lines"></i>
+- label: User manual
+  icon: <i class="fa-regular fa-fw fa-file-lines"></i>
+- label: User's manual
+  icon: <i class="fa-regular fa-fw fa-file-lines"></i>
 - label: Contributor guide
   icon: <i class="fa-regular fa-fw fa-file-lines"></i>
 - label: Contributor's guide

--- a/_software/hpctoolkit.md
+++ b/_software/hpctoolkit.md
@@ -105,6 +105,10 @@ additional_resource_links:
     url: https://gitlab.com/hpctoolkit/hpctoolkit
   - label: Downloads
     url: https://hpctoolkit.org/software.html
-  - label: Documentation
-    url: https://hpctoolkit.org/documentation.html
+  # Link no longer exists
+  # - label: Documentation
+  #   url: https://hpctoolkit.org/documentation.html
+  # This looks like a logical replacement for a documentation link
+  - label: User manual
+    url: https://hpctoolkit.gitlab.io/hpctoolkit/
 ---


### PR DESCRIPTION
Documentation link has gone bad.  Replacing with a link to the User manual