### PR TITLE
Removing FASTMath products no longer receiving stewardship support

### DIFF
--- a/_impacts/2025-01-warpx.md
+++ b/_impacts/2025-01-warpx.md
@@ -18,7 +18,7 @@ excerpt: WarpX is a particle-in-cell (PIC) simulation code that models the motio
 software_mentioned:
   - AMReX
   - libEnsemble
-  - xSDK
+  # - xSDK # No longer part of the CASS portfolio (2025-10-01)
   - Spack
   - E4S
   - HDF5
@@ -53,7 +53,7 @@ WarpX relies on a wide range of other software to deliver its scientific capabil
 {% capture img %}{% include hl-image-path image="2025-01-warpx/warpx-amrex-cropped.png" %}{% endcapture %}
 {% include figure class="align-right" width="50%" popup=true image_path=img alt="Image showing a laser wakefield acceleration" caption="Impact of AMReX integration with WarpX: Simulation of laser wakefield acceleration performed with WarpX. The laser pulse propagates from left to right in a uniform plasma. A moving window is used, i.e. the simulation box travels at the speed of light to follow the laser pulse. The central slice of plasma electrons is shown as transparent white dots. A cavity free of plasma electrons forms in the laser wake, where an electron bunch (solid white dots) is accelerated. The colormap shows the longitudinal electric field in the wake. The white box in the center shows the mesh-refined area.  Image courtesy of Maxence Thévenet & the WarpX team.  Description from [AMReX image gallery](https://amrex-codes.github.io/amrex/gallery.html)." %}
 
-WarpX utilizes a number of mathematical libraries and related tools, including {% include sw-link-mention.html product="AMReX" %} for adaptive mesh refinement capabilities, and {% include sw-link-mention.html product="libEnsemble" %} for parameter studies.  These libraries are part of the {% include sw-link-mention.html product="xSDK" %} Extreme-Scale Scientific Software Development Kit, which provides enhanced interoperability among member libraries, making it easier for WarpX to incorporate additional numerical libraries when needed for future developments.
+WarpX utilizes a number of mathematical libraries and related tools, including {% include sw-link-mention.html product="AMReX" %} for adaptive mesh refinement capabilities, and {% include sw-link-mention.html product="libEnsemble" %} for parameter studies.  These libraries are part of the Extreme-Scale Scientific Software Development Kit (xSDK), which provides enhanced interoperability among member libraries, making it easier for WarpX to incorporate additional numerical libraries when needed for future developments.
 
 ### Software ecosystem and delivery (PESO)
 

--- a/_impacts/2025-01-wdmapp.md
+++ b/_impacts/2025-01-wdmapp.md
@@ -20,16 +20,16 @@ software_mentioned:
   - PETSc/TAO
   - hypre
   - SuperLU
-  - Trilinos
+  # - Trilinos # No longer part of the CASS portfolio (2025-10-01)
   - AMReX
   - MFEM
   - SUNDIALS
   - Kokkos Kernels
   - STRUMPACK
   - libEnsemble
-  - Ginkgo
-  - libCEED
-  - MAGMA
+  # - Ginkgo # No longer part of the CASS portfolio (2025-10-01)
+  # - libCEED # No longer part of the CASS portfolio (2025-10-01)
+  # - MAGMA # No longer part of the CASS portfolio (2025-10-01)
   - Spack
   - E4S
   - ADIOS
@@ -61,7 +61,7 @@ Coupled magnetic fusion simulation codes rely on a wide range of other software 
 
 ### Mathematical libraries (FASTMath)
 
-WDMApp build options bring in the xSDK in order to use many of the FASTMath libraries.  Math libraries in the CASS ecosystem that are used by WDMApp codes, either by default or as variant options, include {% include sw-link-mention.html product="PETSc/TAO" %}, {% include sw-link-mention.html product="hypre" %}, {% include sw-link-mention.html product="SuperLU" %}, {% include sw-link-mention.html product="Trilinos" %}, {% include sw-link-mention.html product="AMReX" %}, {% include sw-link-mention.html product="MFEM" %}, {% include sw-link-mention.html product="SUNDIALS" %}, {% include sw-link-mention.html product="Kokkos Kernels" %}, {% include sw-link-mention.html product="STRUMPACK" %}, {% include sw-link-mention.html product="libEnsemble" %}, {% include sw-link-mention.html product="Ginkgo" %}, {% include sw-link-mention.html product="libCEED" %}, and {% include sw-link-mention.html product="MAGMA" %}.
+WDMApp build options bring in the xSDK in order to use many of the FASTMath libraries.  Math libraries in the CASS ecosystem that are used by WDMApp codes, either by default or as variant options, include {% include sw-link-mention.html product="PETSc/TAO" %}, {% include sw-link-mention.html product="hypre" %}, {% include sw-link-mention.html product="SuperLU" %}, {% include sw-link-mention.html product="AMReX" %}, {% include sw-link-mention.html product="MFEM" %}, {% include sw-link-mention.html product="SUNDIALS" %}, {% include sw-link-mention.html product="Kokkos Kernels" %}, {% include sw-link-mention.html product="STRUMPACK" %}, {% include sw-link-mention.html product="libEnsemble" %}.
 
 ### Software ecosystem and delivery (PESO)
 

--- a/_software/ginkgo.md
+++ b/_software/ginkgo.md
@@ -1,4 +1,7 @@
 ---
+# As of 2025-10-01, this product is no longer receiving stewardship support from FASTMath
+published: false
+#
 # Product information for CASS website product catalog
 #
 # INSTRUCTIONS

--- a/_software/libceed.md
+++ b/_software/libceed.md
@@ -1,4 +1,7 @@
 ---
+# As of 2025-10-01, this product is no longer receiving stewardship support from FASTMath
+published: false
+#
 # Product information for CASS website product catalog
 #
 # INSTRUCTIONS

--- a/_software/magma.md
+++ b/_software/magma.md
@@ -1,4 +1,7 @@
 ---
+# As of 2025-10-01, this product is no longer receiving stewardship support from FASTMath
+published: false
+#
 # Product information for CASS website product catalog
 #
 # INSTRUCTIONS

--- a/_software/trilinos.md
+++ b/_software/trilinos.md
@@ -1,4 +1,7 @@
 ---
+# As of 2025-10-01, this product is no longer receiving stewardship support from FASTMath
+published: false
+#
 # Product information for CASS website product catalog
 #
 # INSTRUCTIONS

--- a/_software/xsdk.md
+++ b/_software/xsdk.md
@@ -1,4 +1,7 @@
 ---
+# As of 2025-10-01, this product is no longer receiving stewardship support from FASTMath
+published: false
+#
 # Product information for CASS website product catalog
 #
 # INSTRUCTIONS

--- a/test.md
+++ b/test.md
@@ -17,7 +17,7 @@ software_mentioned:
   - ADIOS
   - TAU
   - HDF5
-  - Trilinos
+  # - Trilinos # No longer part of the CASS portfolio (2025-10-01)
   - Spack
 #
 feature_row:
@@ -50,8 +50,6 @@ feature_row:
 {% include sw-link-mention.html %}
 
 {% include sw-link-mention.html product="ADIOS" %}
-
-{% include sw-link-mention.html product="Trilinos" %}
 
 {% include sw-link-mention.html product="hdf5" %}
 


### PR DESCRIPTION
As of 2025-10-01 (more or less), the FASTMath portfolio was changed, so we're unpublishing the corresponding catalog entries and removing them from the impact stories in which they appeared.