### PR TITLE
Fix bad links

### DIFF
--- a/_events/hpcbp-webinars/hpcbp-095-fortran.md
+++ b/_events/hpcbp-webinars/hpcbp-095-fortran.md
@@ -32,10 +32,10 @@ artifacts:
   #   yt-video-id: tzPbndr1u4o
   # - label: Slides
   #   format: PDF
-  #   url: https://ideas-productivity.org/assets/artifacts/hpcbp/hpcbp-095-fortran.pdf
+  #   url: XXXXX://ideas-productivity.org/assets/artifacts/hpcbp/hpcbp-095-fortran.pdf
   # - label: Q&A
   #   format: PDF
-  #   url: https://ideas-productivity.org/assets/artifacts/hpcbp/hpcbp-095-fortran-qa.pdf
+  #   url: XXXXX://ideas-productivity.org/assets/artifacts/hpcbp/hpcbp-095-fortran-qa.pdf
 #
 # Items that change rarely
 #

--- a/_software/empirical-roofline-tool.md
+++ b/_software/empirical-roofline-tool.md
@@ -93,7 +93,7 @@ openssf_bestpractices_id:
 additional_resource_links:
   # Website currently broken.  Waiting on Sam Williams to supply a new URL when it is ready
   # - label: Website
-  #   url: https://crd.lbl.gov/divisions/amcr/computer-science-amcr/par/research/roofline/software/ert/
+  #   url: XXXXX://crd.lbl.gov/divisions/amcr/computer-science-amcr/par/research/roofline/software/ert/
   - label: Repository
     url: https://bitbucket.org/berkeleylab/cs-roofline-toolkit/src/master/
   # - label: Downloads

--- a/_software/hpctoolkit.md
+++ b/_software/hpctoolkit.md
@@ -113,7 +113,7 @@ additional_resource_links:
     url: https://hpctoolkit.org/software.html
   # Link no longer exists
   # - label: Documentation
-  #   url: https://hpctoolkit.org/documentation.html
+  #   url: XXXXX://hpctoolkit.org/documentation.html
   # This looks like a logical replacement for a documentation link
   - label: User manual
     url: https://hpctoolkit.gitlab.io/hpctoolkit/

--- a/_software/xsdk.md
+++ b/_software/xsdk.md
@@ -107,7 +107,7 @@ end_user_resource_links:
   # Webpage no longer exists
   # - label: Documentation
   #   note: (installation instructions)
-  #   url: https://xsdk.info/installing-the-software/
+  #   url: XXXXX://xsdk.info/installing-the-software/
   - label: Issue tracker
     url: https://github.com/xsdk-project/xsdk-issues/issues
 #


### PR DESCRIPTION
Unfortunately, our current link checker doesn't understand comments so we can't simply comment out bad links, leaving them as a note for future attention.  So, instead, we're replacing the protocol with XXXXX.  Hopefully that will suffice.