### PR TITLE
Update Elaine's affiliation

### DIFF
--- a/_data/people.yml
+++ b/_data/people.yml
@@ -78,8 +78,8 @@ Drew Paine:
   email: pained@lbl.gov
 
 Elaine Raybourn:
-  affiliation: Sandia National Laboratories
-  short_affil: SNL
+  affiliation: Sandia National Laboratories - Retired
+  short_affil: SNL-Ret.
   email: raybourn@acm.org
 
 Rob Ross:


### PR DESCRIPTION
SNL-Retired, with the expectation that this will be superseded in the foreseeable future.  But so far, it has not gone as quickly as Elaine would like.