### PR TITLE
Go back to globe for websites and webpages

### DIFF
--- a/_data/icon-map.yml
+++ b/_data/icon-map.yml
@@ -9,9 +9,9 @@
 # form `<i class-"fa-something fa-else"></i>`
 
 - label: Website
-  icon: <i class="fa-solid fa-arrow-up-right-from-square"></i>
+  icon: <i class="fa-solid fa-fw fa-globe"></i>
 - label: Webpage
-  icon: <i class="fa-solid fa-arrow-up-right-from-square"></i>
+  icon: <i class="fa-solid fa-fw fa-globe"></i>
 - label: Repository
   icon: <i class="fa-solid fa-fw fa-code"></i>
 # This is intended to denote a link that will directly download a file


### PR DESCRIPTION
I've decided that the square-arrow icon looks more link a general indicator of an external link than a website or webpage.