### PR TITLE
Update participants list on the 2026 Kokkos BoF

### DIFF
--- a/_events/cass-bof-days/2026-02-kokkos.md
+++ b/_events/cass-bof-days/2026-02-kokkos.md
@@ -29,6 +29,8 @@ presenters:
     affiliation: Oak Ridge National Laboratory
   - name: Luc Berger-Vergiat
     affiliation: Sandia National Laboratories
+  - name: Julien Bigot
+    affiliation: French Alternative Energies and Atomic Energy Commission
   - name: Michael Heroux
     affiliation: ParaTools, Inc.
 #


### PR DESCRIPTION
Add Julien Bigot from CEA to the list of participants as member of the Kokkos leadership team.