### PR TITLE
2026 CASS BOF PETSc/TAO: add url

### DIFF
--- a/_events/cass-bof-days/2026-02-petsctao.md
+++ b/_events/cass-bof-days/2026-02-petsctao.md
@@ -47,8 +47,8 @@ presenters:
 
 #
 artifacts:
-   - label: Slides
+   - label: BoF webpage
      url: https://petsc.org/release/community/bofs/2026_Feb_CASS/#feb-cass-petsc-bof
-     note: "The URL has the meeting agenda and slides"
+     note: "(including slides)"
 ---
 PETSc/TAO (The Portable, Extensible Toolkit for Scientific Computation/Toolkit for Advanced Optimization) is a widely used software library for the numerical solution of partial differential equations and related problems. It provides a comprehensive suite of data structures and scalable algorithms that serve as the foundation for large-scale scientific application codes on both serial and parallel platforms. PETSc is used extensively in academia and industry and scales from laptops to the world’s largest GPU-based exascale supercomputers. This PETSc BoF session will serve as a forum for PETSc developers and users to present recent advances. Topics will include new PETSc Fortran bindings, PetscRegressor, TaoTerm, updates to PETSc GPU backends, mixed-precision support in PETSc/MUMPS, and integration with OpenFOAM, among others. PETSc users will share their usage experiences, application successes, and ongoing challenges. The session will include open discussion on emerging PETSc research directions, such as leveraging agentic artificial intelligence to enhance and exploit the PETSc knowledge base. The BoF will provide insight into PETSc’s near-term development roadmap and offer a venue for user feedback on desired features and improvements. Audience questions and participation are strongly encouraged, enabling the PETSc team to better align future development with community needs.

--- a/_events/cass-bof-days/2026-02-petsctao.md
+++ b/_events/cass-bof-days/2026-02-petsctao.md
@@ -46,9 +46,9 @@ presenters:
     affiliation: Lawrence Berkeley National Laboratory
 
 #
-# artifacts:
-#   - label: Slides
-#     url: /assets/artifacts/cass-bof-days/
-#     note: "(PDF)"
+artifacts:
+   - label: Slides
+     url: https://petsc.org/release/community/bofs/2026_Feb_CASS/#feb-cass-petsc-bof
+     note: "The URL has the meeting agenda and slides"
 ---
 PETSc/TAO (The Portable, Extensible Toolkit for Scientific Computation/Toolkit for Advanced Optimization) is a widely used software library for the numerical solution of partial differential equations and related problems. It provides a comprehensive suite of data structures and scalable algorithms that serve as the foundation for large-scale scientific application codes on both serial and parallel platforms. PETSc is used extensively in academia and industry and scales from laptops to the world’s largest GPU-based exascale supercomputers. This PETSc BoF session will serve as a forum for PETSc developers and users to present recent advances. Topics will include new PETSc Fortran bindings, PetscRegressor, TaoTerm, updates to PETSc GPU backends, mixed-precision support in PETSc/MUMPS, and integration with OpenFOAM, among others. PETSc users will share their usage experiences, application successes, and ongoing challenges. The session will include open discussion on emerging PETSc research directions, such as leveraging agentic artificial intelligence to enhance and exploit the PETSc knowledge base. The BoF will provide insight into PETSc’s near-term development roadmap and offer a venue for user feedback on desired features and improvements. Audience questions and participation are strongly encouraged, enabling the PETSc team to better align future development with community needs.


### PR DESCRIPTION
The URL has the meeting agenda and slides