### PR TITLE
Change icons

### DIFF
--- a/_data/icon-map.yml
+++ b/_data/icon-map.yml
@@ -133,11 +133,11 @@
 - label: Q&A
   icon: <i class="fa-regular fa-fw fa-file-lines"></i>
 - label: Tutorial webpage
-  icon: <i class="fa-solid fa-arrow-up-right-from-square"></i>
+  icon: <i class="fa-solid fa-fw fa-globe"></i>
 - label: BoF webpage
-  icon: <i class="fa-solid fa-arrow-up-right-from-square"></i>
+  icon: <i class="fa-solid fa-fw fa-globe"></i>
 - label: Conference program page
-  icon: <i class="fa-solid fa-arrow-up-right-from-square"></i>
+  icon: <i class="fa-solid fa-fw fa-globe"></i>
 - label: Summary blog article
   icon: <i class="fa-regular fa-newspaper"></i>
 #


### PR DESCRIPTION
The fa-arrow-up-right-from-square wasn't a good idea.  It just denotes a link, rather than giving a clue about what's on the end of that link.  These are all webpages, so let's use the same icon as we do for those.