### PR TITLE
Improve navigability of event collection listings

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -155,6 +155,7 @@ defaults:
       classes: wide no-left-sidebar
       event_collection: events
       entries_layout: list
+      back_to_top: true
       author_profile: false
       comments: false
       share: true

--- a/_includes/back-to-top-sticky.html
+++ b/_includes/back-to-top-sticky.html
@@ -1,0 +1,10 @@
+{% comment %}
+    From https://github.com/mmistakes/minimal-mistakes/issues/1731
+    See also __sass/minimal-mistakes.scss (near the bottom) for the CSS class
+
+    Frankly, I'd rather have something like <i class="fa-regular fa-arrow-up-to-line"></i>,
+    but that costs money and the double angles is also commonly used for this.
+{% endcomment %}
+<aside class="back-to-top-sticky">
+<a href="#site-nav" aria-label="Back to top"> <i class="fas fa-angle-double-up"></i></a>
+</aside>

--- a/_includes/show-event-collection.html
+++ b/_includes/show-event-collection.html
@@ -69,7 +69,7 @@
     show_time=my_upcoming_time show_registration=my_upcoming_registration limit=my_upcoming_limit more_url=my_upcoming_more_url %}
 </div>
 
-<{{ my_heading }} id="{{ my_past_id }}">{{ my_past }}</{{ my_heading }}>
+<{{ my_heading }} id="{{ my_past_id }}" style="margin-top: 5em">{{ my_past }}</{{ my_heading }}>
 <div class="entries-{{ my_layout }}">
   {% include ev-documents-collection.html entries=my_entries sort_by=my_sort_by sort_order=my_past_sort_order type=my_layout cutoff=my_cutoff 
         show_time=my_past_time show_registration=my_past_registration limit=my_past_limit more_url=my_past_more_url %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,0 +1,44 @@
+---
+---
+{% comment %}
+  CHANGES FROM DEFAULT DEFAULT LAYOUT
+  * Added call to show stick back-to-top link, following https://github.com/mmistakes/minimal-mistakes/issues/1731#issuecomment-414648689
+    It is protected by a frontmatter setting
+{% endcomment %}
+
+<!doctype html>
+{% include copyright.html %}
+<html lang="{{ site.locale | replace: "_", "-" | default: "en" }}" class="no-js">
+  <head>
+    {% include head.html %}
+    {% include head/custom.html %}
+  </head>
+
+  <body class="layout--{{ page.layout | default: layout.layout }}{% if page.classes or layout.classes %}{{ page.classes | default: layout.classes | join: ' ' | prepend: ' ' }}{% endif %}" dir="{% if site.rtl %}rtl{% else %}ltr{% endif %}">
+    {% include_cached skip-links.html %}
+    {% include_cached masthead.html %}
+
+    <div class="initial-content">
+      {{ content }}
+      {% include after-content.html %}
+    </div>
+
+    {% if site.search == true %}
+      <div class="search-content">
+        {% include_cached search/search_form.html %}
+      </div>
+    {% endif %}
+
+    <div id="footer" class="page__footer">
+      <footer>
+        {% include footer/custom.html %}
+        {% include_cached footer.html %}
+      </footer>
+    </div>
+    {% if page.back_to_top %}
+      {% include back-to-top-sticky.html %}
+    {% endif %}
+
+    {% include scripts.html %}
+  </body>
+</html>

--- a/_sass/minimal-mistakes.scss
+++ b/_sass/minimal-mistakes.scss
@@ -95,3 +95,40 @@
     }
   }
 }
+
+/* A back-to-top icon that sticks to the bottom right corner.
+   MM already has a .back-to-top class, for non-sticky text links.
+   So this needs to be different.
+
+   Basic implementation from: https://github.com/mmistakes/minimal-mistakes/issues/1731
+   Additional styling ideas based on https://www.fabriziomusacchio.com/blog/2022-06-30-Markdown_back_to_top_button/
+
+   I've experimented with various background colors and white seems best to me.  $light-gray and even $lighter-gray don't
+   stand out enough for my taste.  White matches the color used on .btn--inverse.  Though we haven't derived it in the same way.
+
+   HTML side it implemented in _includes/back-to-top-sticky.html, which is included in default.html and controlled
+   by a frontmatter setting `back_to_top: true` to make it easy to use or not.
+
+   Room for improvement:
+    https://theosoti.com/short/back-to-top/ and https://codepen.io/theosoti/pen/KwdzKGx referenced therein have the
+    icon sliding in and out as you start scrolling down, which I kind of like.
+*/
+
+.back-to-top-sticky {
+  position: fixed;
+  bottom: 1em;
+  right: 1em;
+  z-index: 10;
+
+  display:          inline-flex;
+  color:            $muted-text-color;
+  cursor:           pointer;
+  align-items:      center;
+  justify-content:  center;
+  margin:           0em 2em 2em 0em;
+  border-radius:    50%;
+  padding:          .25em;
+  width:            2em;
+  height:           2em;
+  background-color: white;
+}

--- a/_working-groups/user-developer-experience.md
+++ b/_working-groups/user-developer-experience.md
@@ -59,6 +59,7 @@ additional_resource_links:
     icon: <i class="fa-regular fa-file-lines"></i>
 event_collection: events
 series: "User/Developer Experience Webinars"
+back_to_top: true
 ---
 {% capture seminars_icon %}{% include icon-map-lookup label="Seminars" %}{% endcapture %}
 

--- a/events.md
+++ b/events.md
@@ -6,6 +6,7 @@ collection: events
 entries_layout: list
 layout: ev-collection
 classes: wide no-left-sidebar
+back_to_top: true
 header:
   overlay_filter: rgba(0, 146, 202, 0.75) # Same color as "air" skin footer
   overlay_image: /assets/images/headway-F2KRf_QfCqw-unsplash.jpg

--- a/software-areas.md
+++ b/software-areas.md
@@ -6,6 +6,7 @@ collection: software
 sort_by: name
 entries_layout: grid
 layout: sw-collection-areas
+back_to_top: true
 # layout: splash # Default: home, but that includes a list of posts
 classes: wide
 header:


### PR DESCRIPTION
Trying to provide more visible distinction   between upcoming and past, to aid navigation.

Also adding a back-to-top button that sticks to the lower right corner.