### PR TITLE
Change UDX-led activities to use the full working group name

### DIFF
--- a/_events/udx-webinars/udx-2025july-sochat.md
+++ b/_events/udx-webinars/udx-2025july-sochat.md
@@ -38,7 +38,7 @@ type: Webinar
 series:
   - "User/Developer Experience Webinars"
 activities:
-  - "UDX Working Group"
+  - "User-Developer Experience"
 #
 ---
 *User/Developer Experience Webinars feature speakers who highlight best practices and challenges for usable scientific software. Have a suggestion for a future meeting? Use [this Google form](https://docs.google.com/forms/d/e/1FAIpQLSe0ss98Bh1otRaleBii_LcADeGeGvluav6O3oxFIwZo6d4Xzg/viewform) to propose ideas.*

--- a/_events/udx-webinars/udx-2025may-brown.md
+++ b/_events/udx-webinars/udx-2025may-brown.md
@@ -40,7 +40,7 @@ type: Webinar
 series:
   - "User/Developer Experience Webinars"
 activities:
-  - "UDX Working Group"
+  - "User-Developer Experience"
 #
 ---
 *User/Developer Experience Webinars feature speakers who highlight best practices and challenges for usable scientific software. Have a suggestion for a future meeting? Use [this Google form](https://docs.google.com/forms/d/e/1FAIpQLSe0ss98Bh1otRaleBii_LcADeGeGvluav6O3oxFIwZo6d4Xzg/viewform) to propose ideas.*

--- a/_events/udx-webinars/udx-2025sep-rock.md
+++ b/_events/udx-webinars/udx-2025sep-rock.md
@@ -45,7 +45,7 @@ type: Webinar
 series:
   - "User/Developer Experience Webinars"
 activities:
-  - "UDX Working Group"
+  - "User-Developer Experience"
 #
 ---
 *User/Developer Experience Webinars feature speakers who highlight best practices and challenges for usable scientific software. Have a suggestion for a future meeting? Use [this Google form](https://docs.google.com/forms/d/e/1FAIpQLSe0ss98Bh1otRaleBii_LcADeGeGvluav6O3oxFIwZo6d4Xzg/viewform) to propose ideas.*

--- a/_events/udx-webinars/udx-2026april-disc.md
+++ b/_events/udx-webinars/udx-2026april-disc.md
@@ -54,7 +54,7 @@ type: Open Discussion
 series:
   - "User/Developer Experience Webinars"
 activities:
-  - "UDX Working Group" 
+  - "User-Developer Experience" 
 #
 ---
 The User/Developer Experience (UDX) Working group hosts a regular discussion hour on UDX topics to complement our every-other-month webinars. 

--- a/_events/udx-webinars/udx-2026jan-vantuyl.md
+++ b/_events/udx-webinars/udx-2026jan-vantuyl.md
@@ -50,7 +50,7 @@ type: Webinar
 series:
   - "User/Developer Experience Webinars"
 activities:
-  - "UDX Working Group"
+  - "User-Developer Experience"
 #
 ---
 *User/Developer Experience Webinars feature speakers who highlight best practices and challenges for usable scientific software. Have a suggestion for a future meeting? Use [this Google form](https://docs.google.com/forms/d/e/1FAIpQLSe0ss98Bh1otRaleBii_LcADeGeGvluav6O3oxFIwZo6d4Xzg/viewform) to propose ideas.*

--- a/_events/udx-webinars/udx-2026march-newton.md
+++ b/_events/udx-webinars/udx-2026march-newton.md
@@ -58,7 +58,7 @@ type: Webinar
 series:
   - "User/Developer Experience Webinars"
 activities:
-  - "UDX Working Group" 
+  - "User-Developer Experience" 
 #
 ---
 *User/Developer Experience Webinars feature speakers who highlight best practices and challenges for usable scientific software. Have a suggestion for a future meeting? Use [this Google form](https://docs.google.com/forms/d/e/1FAIpQLSe0ss98Bh1otRaleBii_LcADeGeGvluav6O3oxFIwZo6d4Xzg/viewform) to propose ideas.*

--- a/_events/udx-webinars/udx-2026may-kim.md
+++ b/_events/udx-webinars/udx-2026may-kim.md
@@ -53,7 +53,7 @@ type: Webinar
 series:
   - "User/Developer Experience Webinars"
 activities:
-  - "UDX Working Group" 
+  - "User-Developer Experience" 
 #
 ---
 *User/Developer Experience Webinars feature speakers who highlight best practices and challenges for usable scientific software. Have a suggestion for a future meeting? Use [this Google form](https://docs.google.com/forms/d/e/1FAIpQLSe0ss98Bh1otRaleBii_LcADeGeGvluav6O3oxFIwZo6d4Xzg/viewform) to propose ideas.*


### PR DESCRIPTION
This doesn't matter right now because we're not processing `activities` for anything currently.  But if/when we do, this should enable making more systematic connections to the WG name/page.